### PR TITLE
Fix typo at required_action permissions

### DIFF
--- a/src/spaceone/identity/service/token_service.py
+++ b/src/spaceone/identity/service/token_service.py
@@ -222,7 +222,7 @@ class TokenService(BaseService):
     def _get_permissions_from_required_actions(user_vo: User) -> Union[List[str], None]:
         if "UPDATE_PASSWORD" in user_vo.required_actions:
             return [
-                "identity.UserProfile",
+                "identity:UserProfile",
             ]
 
         return None


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- fix typo at required_action permissions
   - '.' -> ':'
### Known issue
