### PR TITLE
Fix BaseDict' object has no attribute 'to_dict' error when sync

### DIFF
--- a/src/spaceone/identity/manager/__init__.py
+++ b/src/spaceone/identity/manager/__init__.py
@@ -1,0 +1,1 @@
+from spaceone.identity.manager.plugin_manager import PluginManager

--- a/src/spaceone/identity/manager/account_collector_plugin_manager.py
+++ b/src/spaceone/identity/manager/account_collector_plugin_manager.py
@@ -56,14 +56,14 @@ class AccountCollectorPluginManager(BaseManager):
         return plugin_connector.dispatch("AccountCollector.sync", params)
 
     def get_account_collector_plugin_endpoint_by_vo(self, provider_vo: Provider) -> str:
-        plugin_info = provider_vo.plugin_info.to_dict()
+        plugin_info = provider_vo.plugin_info
         endpoint, updated_version = self.get_account_collector_plugin_endpoint(
             plugin_info, provider_vo.domain_id
         )
 
         if updated_version:
             _LOGGER.debug(
-                f'[get_account_collector_plugin_endpoint_by_vo] upgrade plugin version: {plugin_info["version"]} -> {updated_version}'
+                f'[get_account_collector_plugin_endpoint_by_vo] upgrade plugin version: {plugin_info.get("version")} -> {updated_version}'
             )
             self.upgrade_account_collector_plugin_version(
                 provider_vo, endpoint, updated_version
@@ -80,7 +80,7 @@ class AccountCollectorPluginManager(BaseManager):
     def upgrade_account_collector_plugin_version(
         self, provider_vo: Provider, endpoint: str, updated_version: str
     ) -> None:
-        plugin_info = provider_vo.plugin_info.to_dict()
+        plugin_info = provider_vo.plugin_info
         domain_id = provider_vo.domain_id
 
         self.initialize(endpoint)

--- a/src/spaceone/identity/service/trusted_account_service.py
+++ b/src/spaceone/identity/service/trusted_account_service.py
@@ -244,7 +244,7 @@ class TrustedAccountService(BaseService):
             JobResponse: 'dict'
         """
 
-        job_service: JobService = self.locator.get_service("JobService")
+        job_service = JobService()
 
         trusted_account_id = params.trusted_account_id
         workspace_id = params.workspace_id


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- fix BaseDict' object has no attribute 'to_dict' error when sync …
### Known issue
* #199 