### PR TITLE
fix error when creating secret_id is None during auto sync

### DIFF
--- a/src/spaceone/identity/service/job_service.py
+++ b/src/spaceone/identity/service/job_service.py
@@ -871,9 +871,11 @@ class JobService(BaseService):
         if secret_data:
             secret_mgr: SecretManager = self.locator.get_manager("SecretManager")
             secret_id = service_account_vo.secret_id
+            secret_total_count = 0
 
-            response = secret_mgr.list_secrets({"secret_id": secret_id}, domain_id)
-            secret_total_count = response.get("total_count", 0)
+            if secret_id:
+                response = secret_mgr.list_secrets({"secret_id": secret_id}, domain_id)
+                secret_total_count = response.get("total_count", 0)
 
             if secret_total_count > 0:
                 update_secret_params = {


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- fix error when creating secret_id is None during auto sync
### Known issue
