### PR TITLE
fix: set default value for tags field to an empty dictionary

### DIFF
--- a/src/spaceone/identity/model/user/database.py
+++ b/src/spaceone/identity/model/user/database.py
@@ -36,7 +36,7 @@ class User(MongoModel):
     required_actions = ListField(StringField(choices=("UPDATE_PASSWORD",)), default=[])
     language = StringField(max_length=7, default="en")
     timezone = StringField(max_length=50, default="UTC")
-    tags = DictField(default=None)
+    tags = DictField(default={})
     domain_id = StringField(max_length=40)
     created_at = DateTimeField(auto_now_add=True)
     last_accessed_at = DateTimeField(default=None, null=True)


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
* set default value for tags field to an empty dictionary
