### PR TITLE
reafactor: Remove the rule that a workspace must always have one owner

### DIFF
--- a/src/spaceone/identity/service/domain_service.py
+++ b/src/spaceone/identity/service/domain_service.py
@@ -90,8 +90,7 @@ class DomainService(BaseService):
             "role_type": role_vos[0].role_type,
         }
 
-        rb_vo = role_binding_mgr.create_role_binding(params_rb)
-        self._update_workspace_user_count(rb_vo.workspace_id, rb_vo.domain_id)
+        role_binding_mgr.create_role_binding(params_rb)
 
         return DomainResponse(**domain_vo.to_dict())
 
@@ -296,6 +295,9 @@ class DomainService(BaseService):
         return len(user_rb_ids)
 
     def _update_workspace_user_count(self, workspace_id: str, domain_id: str) -> None:
+        if not workspace_id and not domain_id:
+            return
+
         workspace_vo = self.workspace_mgr.get_workspace(workspace_id, domain_id)
 
         if workspace_vo and workspace_vo.workspace_id != "*":

--- a/src/spaceone/identity/service/domain_service.py
+++ b/src/spaceone/identity/service/domain_service.py
@@ -1,22 +1,22 @@
 import logging
 from typing import Union
 
-from spaceone.core.service import *
-from spaceone.core.service.utils import *
 from spaceone.core import utils
 from spaceone.core.auth.jwt import JWTAuthenticator
-
-from spaceone.identity.manager.external_auth_manager import ExternalAuthManager
+from spaceone.core.service import *
+from spaceone.core.service.utils import *
+from spaceone.identity.error.error_domain import *
+from spaceone.identity.manager.config_manager import ConfigManager
 from spaceone.identity.manager.domain_manager import DomainManager
 from spaceone.identity.manager.domain_secret_manager import DomainSecretManager
-from spaceone.identity.manager.role_manager import RoleManager
+from spaceone.identity.manager.external_auth_manager import ExternalAuthManager
 from spaceone.identity.manager.role_binding_manager import RoleBindingManager
-from spaceone.identity.manager.user_manager import UserManager
-from spaceone.identity.manager.config_manager import ConfigManager
+from spaceone.identity.manager.role_manager import RoleManager
 from spaceone.identity.manager.system_manager import SystemManager
+from spaceone.identity.manager.user_manager import UserManager
+from spaceone.identity.manager.workspace_manager import WorkspaceManager
 from spaceone.identity.model.domain.request import *
 from spaceone.identity.model.domain.response import *
-from spaceone.identity.error.error_domain import *
 from spaceone.identity.service.user_service import UserService
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,6 +35,8 @@ class DomainService(BaseService):
         self.domain_secret_mgr = DomainSecretManager()
         self.user_mgr = UserManager()
         self.role_manager = RoleManager()
+        self.rb_mgr = RoleBindingManager()
+        self.workspace_mgr = WorkspaceManager()
 
     @transaction(permission="identity:Domain.write", role_types=["SYSTEM_ADMIN"])
     @convert_model
@@ -87,7 +89,9 @@ class DomainService(BaseService):
             "domain_id": user_vo.domain_id,
             "role_type": role_vos[0].role_type,
         }
-        role_binding_mgr.create_role_binding(params_rb)
+
+        rb_vo = role_binding_mgr.create_role_binding(params_rb)
+        self._update_workspace_user_count(rb_vo.workspace_id, rb_vo.domain_id)
 
         return DomainResponse(**domain_vo.to_dict())
 
@@ -228,7 +232,7 @@ class DomainService(BaseService):
             root_domain_id = SystemManager.get_root_domain_id()
             root_pub_jwk = self.domain_secret_mgr.get_domain_public_key(root_domain_id)
             JWTAuthenticator(root_pub_jwk).validate(token)
-        except Exception as e:
+        except Exception:
             raise ERROR_UNKNOWN(message="Invalid System Token")
 
         # Get Public Key from Domain
@@ -278,3 +282,26 @@ class DomainService(BaseService):
 
         query = params.query or {}
         return self.domain_mgr.stat_domains(query)
+
+    def _get_workspace_user_count(self, workspace_id: str, domain_id: str) -> int:
+        user_rb_ids = self.rb_mgr.stat_role_bindings(
+            query={
+                "distinct": "user_id",
+                "filter": [
+                    {"k": "workspace_id", "v": workspace_id, "o": "eq"},
+                    {"k": "domain_id", "v": domain_id, "o": "eq"},
+                ],
+            }
+        ).get("results", [])
+        return len(user_rb_ids)
+
+    def _update_workspace_user_count(self, workspace_id: str, domain_id: str) -> None:
+        workspace_vo = self.workspace_mgr.get_workspace(workspace_id, domain_id)
+
+        if workspace_vo and workspace_vo.workspace_id != "*":
+            user_rb_total_count = self._get_workspace_user_count(
+                workspace_id, domain_id
+            )
+            self.workspace_mgr.update_workspace_by_vo(
+                {"user_count": user_rb_total_count}, workspace_vo
+            )

--- a/src/spaceone/identity/service/role_binding_service.py
+++ b/src/spaceone/identity/service/role_binding_service.py
@@ -465,6 +465,9 @@ class RoleBindingService(BaseService):
         return len(user_rb_ids)
 
     def _update_workspace_user_count(self, workspace_id: str, domain_id: str) -> None:
+        if not workspace_id and not domain_id:
+            return
+
         workspace_vo = self.workspace_mgr.get_workspace(workspace_id, domain_id)
 
         if workspace_vo and workspace_vo.workspace_id != "*":

--- a/src/spaceone/identity/service/role_binding_service.py
+++ b/src/spaceone/identity/service/role_binding_service.py
@@ -163,12 +163,6 @@ class RoleBindingService(BaseService):
                     request_role_type=new_role_vo.role_type,
                     supported_role_type=["WORKSPACE_OWNER", "WORKSPACE_MEMBER"],
                 )
-            self.check_last_workspace_owner_role_binding(
-                rb_vo.user_id,
-                new_role_vo.role_type,
-                rb_vo.workspace_id,
-                rb_vo.domain_id,
-            )
         elif rb_vo.role_type == new_role_vo.role_type:
             self.check_last_domain_admin_role_binding(
                 rb_vo.user_id,
@@ -249,12 +243,12 @@ class RoleBindingService(BaseService):
             self.check_last_domain_admin_role_binding(
                 rb_vo.user_id, None, rb_vo.domain_id
             )
-        elif rb_vo.role_type == "WORKSPACE_OWNER":
-            self.check_last_workspace_owner_role_binding(
-                rb_vo.user_id, None, rb_vo.workspace_id, rb_vo.domain_id
-            )
 
-        # Update user role type
+        # Update the user's representative role_type.
+        # A user's role_type is a single, domain-level field that summarizes their highest-priority role.
+        # Since deleting a role binding (even a workspace-specific one) might change this representative role,
+        # we must re-evaluate all of the user's remaining role bindings across the entire domain
+        # to determine their new, correct role_type.
         remain_rb_vos = self.role_binding_manager.filter_role_bindings(
             domain_id=params.domain_id, user_id=rb_vo.user_id
         )
@@ -417,27 +411,6 @@ class RoleBindingService(BaseService):
         if rb_vos.count() == 1 and new_role_type != "DOMAIN_ADMIN":
             raise ERROR_LAST_DOMAIN_ADMIN_CANNOT_DELETE()
 
-    def check_last_workspace_owner_role_binding(
-        self,
-        user_id: str,
-        new_role_type: Union[str, None],
-        workspace_id: str,
-        domain_id: str,
-    ) -> None:
-        user_ids = self._get_enabled_user_ids(domain_id)
-        rb_vos = self.role_binding_manager.filter_role_bindings(
-            domain_id=domain_id,
-            workspace_id=workspace_id,
-            user_id=user_ids,
-            role_type="WORKSPACE_OWNER",
-        )
-
-        if not rb_vos.filter(user_id=user_id):
-            return None
-
-        if rb_vos.count() == 1 and new_role_type != "WORKSPACE_OWNER":
-            raise ERROR_LAST_WORKSPACE_OWNER_CANNOT_DELETE()
-
     def _get_enabled_user_ids(self, domain_id: str) -> list:
         user_vos = self.user_mgr.filter_users(
             domain_id=domain_id,
@@ -453,6 +426,11 @@ class RoleBindingService(BaseService):
 
     @staticmethod
     def _get_latest_role_type(before: str, after: str) -> str:
+        # Determines the user's representative role by comparing priorities (lower number is higher).
+        # Policy: Workspace-level roles (OWNER, MEMBER) grant permissions within a workspace
+        # but do not elevate the user's fundamental role at the domain level.
+        # Therefore, if a user's highest role is a workspace role, their representative
+        # role_type defaults to 'USER'. Only 'DOMAIN_ADMIN' elevates this status.
         priority = {
             "DOMAIN_ADMIN": 1,
             "WORKSPACE_OWNER": 2,

--- a/src/spaceone/identity/service/role_service.py
+++ b/src/spaceone/identity/service/role_service.py
@@ -113,6 +113,14 @@ class RoleService(BaseService):
         """
 
         role_vo = self.role_mgr.get_role(params.role_id, params.domain_id)
+
+        rb_vos = self.rb_mgr.filter_role_bindings(
+            role_id=role_vo.role_id, domain_id=role_vo.domain_id
+        )
+
+        if rb_vos.count() > 0:
+            raise ERROR_ROLE_IN_USED_AT_ROLE_BINDING(role_id=role_vo.role_id)
+
         role_vo = self.role_mgr.disable_role_by_vo(role_vo)
 
         return RoleResponse(**role_vo.to_dict())

--- a/src/spaceone/identity/service/system_service.py
+++ b/src/spaceone/identity/service/system_service.py
@@ -96,7 +96,7 @@ class SystemService(BaseService):
                 _LOGGER.debug(
                     f"[init] Delete existing user in root domain: {user_vo.user_id}"
                 )
-                self.delete_user_by_vo(user_vo)
+                self._delete_user_by_vo(user_vo)
 
         # create admin user
         _LOGGER.debug(f"[init] Create admin user: {params.admin.user_id}")
@@ -144,7 +144,7 @@ class SystemService(BaseService):
 
         return SystemResponse(**response)
 
-    def delete_user_by_vo(self, user_vo: User) -> None:
+    def _delete_user_by_vo(self, user_vo: User) -> None:
         # Delete role bindings
         rb_vos = self.role_binding_manager.filter_role_bindings(
             user_id=user_vo.user_id, domain_id=user_vo.domain_id
@@ -209,6 +209,9 @@ class SystemService(BaseService):
         return len(user_rb_ids)
 
     def _update_workspace_user_count(self, workspace_id: str, domain_id: str) -> None:
+        if not workspace_id and not domain_id:
+            return
+
         workspace_vo = self.workspace_mgr.get_workspace(workspace_id, domain_id)
 
         if workspace_vo and workspace_vo.workspace_id != "*":

--- a/src/spaceone/identity/service/system_service.py
+++ b/src/spaceone/identity/service/system_service.py
@@ -1,20 +1,24 @@
 import logging
 from typing import Union
 
+from spaceone.core.auth.jwt import JWTAuthenticator
 from spaceone.core.service import *
 from spaceone.core.service.utils import *
-from spaceone.core.auth.jwt import JWTAuthenticator
-
+from spaceone.identity.error.error_domain import *
+from spaceone.identity.error.error_system import *
 from spaceone.identity.manager.domain_manager import DomainManager
 from spaceone.identity.manager.domain_secret_manager import DomainSecretManager
-from spaceone.identity.manager.role_manager import RoleManager
+from spaceone.identity.manager.project_manager import ProjectManager
 from spaceone.identity.manager.role_binding_manager import RoleBindingManager
-from spaceone.identity.manager.user_manager import UserManager
+from spaceone.identity.manager.role_manager import RoleManager
 from spaceone.identity.manager.system_manager import SystemManager
+from spaceone.identity.manager.user_group_manager import UserGroupManager
+from spaceone.identity.manager.user_manager import UserManager
+from spaceone.identity.manager.workspace_group_manager import WorkspaceGroupManager
+from spaceone.identity.manager.workspace_manager import WorkspaceManager
 from spaceone.identity.model.system.request import *
 from spaceone.identity.model.system.response import *
-from spaceone.identity.error.error_system import *
-from spaceone.identity.error.error_domain import *
+from spaceone.identity.model.user.database import User
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +33,13 @@ class SystemService(BaseService):
         self.domain_secret_mgr = DomainSecretManager()
         self.user_mgr = UserManager()
         self.role_manager = RoleManager()
+        self.role_binding_manager = RoleBindingManager()
+        self.workspace_mgr = WorkspaceManager()
+        self.workspace_group_mgr = WorkspaceGroupManager()
+        self.user_mgr = UserManager()
+        self.user_group_mgr = UserGroupManager()
+        self.project_mgr = ProjectManager()
+        self.workspace_group_mgr = WorkspaceGroupManager()
 
     @transaction()
     @convert_model
@@ -68,7 +79,7 @@ class SystemService(BaseService):
                     root_domain_id
                 )
                 JWTAuthenticator(root_pub_jwk).validate(token)
-            except Exception as e:
+            except Exception:
                 raise ERROR_UNKNOWN(message="Invalid System Token")
 
             root_domain_vo = root_domain_vos[0]
@@ -85,7 +96,7 @@ class SystemService(BaseService):
                 _LOGGER.debug(
                     f"[init] Delete existing user in root domain: {user_vo.user_id}"
                 )
-                self.user_mgr.delete_user_by_vo(user_vo)
+                self.delete_user_by_vo(user_vo)
 
         # create admin user
         _LOGGER.debug(f"[init] Create admin user: {params.admin.user_id}")
@@ -118,7 +129,8 @@ class SystemService(BaseService):
             "domain_id": user_vo.domain_id,
             "role_type": role_vos[0].role_type,
         }
-        role_binding_mgr.create_role_binding(params_rb)
+        rb_vo = role_binding_mgr.create_role_binding(params_rb)
+        self._update_workspace_user_count(rb_vo.workspace_id, rb_vo.domain_id)
 
         system_token = system_mgr.create_system_token(
             root_domain_vo.domain_id, user_vo.user_id
@@ -131,3 +143,78 @@ class SystemService(BaseService):
         }
 
         return SystemResponse(**response)
+
+    def delete_user_by_vo(self, user_vo: User) -> None:
+        # Delete role bindings
+        rb_vos = self.role_binding_manager.filter_role_bindings(
+            user_id=user_vo.user_id, domain_id=user_vo.domain_id
+        )
+        for rb_vo in rb_vos:
+            self.role_binding_manager.delete_role_binding_by_vo(rb_vo)
+            self._update_workspace_user_count(rb_vo.workspace_id, rb_vo.domain_id)
+
+        # Delete user from user groups
+        user_group_vos = self.user_group_mgr.filter_user_groups(
+            users=user_vo.user_id, domain_id=user_vo.domain_id
+        )
+        for user_group_vo in user_group_vos:
+            users = user_group_vo.users
+            users.remove(user_vo.user_id)
+            self.user_group_mgr.update_user_group_by_vo(
+                {"users": users}, user_group_vo=user_group_vo
+            )
+
+        # Delete projects
+        project_vos = self.project_mgr.filter_projects(
+            users=user_vo.user_id, domain_id=user_vo.domain_id
+        )
+        for project_vo in project_vos:
+            users = project_vo.users
+            users.remove(user_vo.user_id)
+            self.project_mgr.update_project_by_vo(
+                {"users": users}, project_vo=project_vo
+            )
+
+        # Delete workspace groups
+        workspace_group_vos = self.workspace_group_mgr.filter_workspace_groups(
+            users__user_id=user_vo.user_id, domain_id=user_vo.domain_id
+        )
+
+        for workspace_group_vo in workspace_group_vos:
+            workspace_group_dict = workspace_group_vo.to_mongo().to_dict()
+            users = workspace_group_dict.get("users", [])
+
+            if users:
+                updated_users = [
+                    user for user in users if user.get("user_id") != user_vo.user_id
+                ]
+
+                if len(updated_users) != len(users):
+                    self.workspace_group_mgr.update_workspace_group_by_vo(
+                        {"users": updated_users}, workspace_group_vo=workspace_group_vo
+                    )
+
+        self.user_mgr.delete_user(user_vo)
+
+    def _get_workspace_user_count(self, workspace_id: str, domain_id: str) -> int:
+        user_rb_ids = self.role_binding_manager.stat_role_bindings(
+            query={
+                "distinct": "user_id",
+                "filter": [
+                    {"k": "workspace_id", "v": workspace_id, "o": "eq"},
+                    {"k": "domain_id", "v": domain_id, "o": "eq"},
+                ],
+            }
+        ).get("results", [])
+        return len(user_rb_ids)
+
+    def _update_workspace_user_count(self, workspace_id: str, domain_id: str) -> None:
+        workspace_vo = self.workspace_mgr.get_workspace(workspace_id, domain_id)
+
+        if workspace_vo and workspace_vo.workspace_id != "*":
+            user_rb_total_count = self._get_workspace_user_count(
+                workspace_id, domain_id
+            )
+            self.workspace_mgr.update_workspace_by_vo(
+                {"user_count": user_rb_total_count}, workspace_vo
+            )

--- a/src/spaceone/identity/service/user_service.py
+++ b/src/spaceone/identity/service/user_service.py
@@ -16,10 +16,12 @@ from spaceone.identity.manager.domain_manager import DomainManager
 from spaceone.identity.manager.domain_secret_manager import DomainSecretManager
 from spaceone.identity.manager.email_manager import EmailManager
 from spaceone.identity.manager.external_auth_manager import ExternalAuthManager
-from spaceone.identity.manager.token_manager.local_token_manager import (
-    LocalTokenManager,
-)
+from spaceone.identity.manager.project_manager import ProjectManager
+from spaceone.identity.manager.role_binding_manager import RoleBindingManager
+from spaceone.identity.manager.user_group_manager import UserGroupManager
 from spaceone.identity.manager.user_manager import UserManager
+from spaceone.identity.manager.workspace_group_manager import WorkspaceGroupManager
+from spaceone.identity.manager.workspace_manager import WorkspaceManager
 from spaceone.identity.model.user.database import User
 from spaceone.identity.model.user.request import *
 from spaceone.identity.model.user.response import *
@@ -39,6 +41,11 @@ class UserService(BaseService):
         self.user_mgr = UserManager()
         self.domain_mgr = DomainManager()
         self.domain_secret_mgr = DomainSecretManager()
+        self.rb_mgr = RoleBindingManager()
+        self.user_group_mgr = UserGroupManager()
+        self.project_mgr = ProjectManager()
+        self.workspace_mgr = WorkspaceManager()
+        self.workspace_group_mgr = WorkspaceGroupManager()
 
     @transaction(permission="identity:User.write", role_types=["DOMAIN_ADMIN"])
     @convert_model
@@ -418,7 +425,7 @@ class UserService(BaseService):
         if user_vo.role_type == "DOMAIN_ADMIN" and user_vo.state == "ENABLED":
             self._check_last_admin_user(params.domain_id, user_vo)
 
-        self.user_mgr.delete_user_by_vo(user_vo)
+        self.delete_user_by_vo(user_vo)
 
     @transaction(permission="identity:User.write", role_types=["DOMAIN_ADMIN"])
     @convert_model
@@ -912,3 +919,78 @@ class UserService(BaseService):
             and enforce_mfa_type != user_mfa_type
             and user_mfa_type is not None
         )
+
+    def delete_user_by_vo(self, user_vo: User) -> None:
+        # Delete role bindings
+        rb_vos = self.rb_mgr.filter_role_bindings(
+            user_id=user_vo.user_id, domain_id=user_vo.domain_id
+        )
+        for rb_vo in rb_vos:
+            self.rb_mgr.delete_role_binding_by_vo(rb_vo)
+            self._update_workspace_user_count(rb_vo.workspace_id, rb_vo.domain_id)
+
+        # Delete user from user groups
+        user_group_vos = self.user_group_mgr.filter_user_groups(
+            users=user_vo.user_id, domain_id=user_vo.domain_id
+        )
+        for user_group_vo in user_group_vos:
+            users = user_group_vo.users
+            users.remove(user_vo.user_id)
+            self.user_group_mgr.update_user_group_by_vo(
+                {"users": users}, user_group_vo=user_group_vo
+            )
+
+        # Delete projects
+        project_vos = self.project_mgr.filter_projects(
+            users=user_vo.user_id, domain_id=user_vo.domain_id
+        )
+        for project_vo in project_vos:
+            users = project_vo.users
+            users.remove(user_vo.user_id)
+            self.project_mgr.update_project_by_vo(
+                {"users": users}, project_vo=project_vo
+            )
+
+        # Delete workspace groups
+        workspace_group_vos = self.workspace_group_mgr.filter_workspace_groups(
+            users__user_id=user_vo.user_id, domain_id=user_vo.domain_id
+        )
+
+        for workspace_group_vo in workspace_group_vos:
+            workspace_group_dict = workspace_group_vo.to_mongo().to_dict()
+            users = workspace_group_dict.get("users", [])
+
+            if users:
+                updated_users = [
+                    user for user in users if user.get("user_id") != user_vo.user_id
+                ]
+
+                if len(updated_users) != len(users):
+                    self.workspace_group_mgr.update_workspace_group_by_vo(
+                        {"users": updated_users}, workspace_group_vo=workspace_group_vo
+                    )
+
+        self.user_mgr.delete_user(user_vo)
+
+    def _get_workspace_user_count(self, workspace_id: str, domain_id: str) -> int:
+        user_rb_ids = self.rb_mgr.stat_role_bindings(
+            query={
+                "distinct": "user_id",
+                "filter": [
+                    {"k": "workspace_id", "v": workspace_id, "o": "eq"},
+                    {"k": "domain_id", "v": domain_id, "o": "eq"},
+                ],
+            }
+        ).get("results", [])
+        return len(user_rb_ids)
+
+    def _update_workspace_user_count(self, workspace_id: str, domain_id: str) -> None:
+        workspace_vo = self.workspace_mgr.get_workspace(workspace_id, domain_id)
+
+        if workspace_vo and workspace_vo.workspace_id != "*":
+            user_rb_total_count = self._get_workspace_user_count(
+                workspace_id, domain_id
+            )
+            self.workspace_mgr.update_workspace_by_vo(
+                {"user_count": user_rb_total_count}, workspace_vo
+            )

--- a/src/spaceone/identity/service/user_service.py
+++ b/src/spaceone/identity/service/user_service.py
@@ -425,7 +425,7 @@ class UserService(BaseService):
         if user_vo.role_type == "DOMAIN_ADMIN" and user_vo.state == "ENABLED":
             self._check_last_admin_user(params.domain_id, user_vo)
 
-        self.delete_user_by_vo(user_vo)
+        self._delete_user_by_vo(user_vo)
 
     @transaction(permission="identity:User.write", role_types=["DOMAIN_ADMIN"])
     @convert_model
@@ -920,7 +920,7 @@ class UserService(BaseService):
             and user_mfa_type is not None
         )
 
-    def delete_user_by_vo(self, user_vo: User) -> None:
+    def _delete_user_by_vo(self, user_vo: User) -> None:
         # Delete role bindings
         rb_vos = self.rb_mgr.filter_role_bindings(
             user_id=user_vo.user_id, domain_id=user_vo.domain_id
@@ -985,6 +985,9 @@ class UserService(BaseService):
         return len(user_rb_ids)
 
     def _update_workspace_user_count(self, workspace_id: str, domain_id: str) -> None:
+        if not workspace_id and not domain_id:
+            return
+
         workspace_vo = self.workspace_mgr.get_workspace(workspace_id, domain_id)
 
         if workspace_vo and workspace_vo.workspace_id != "*":

--- a/src/spaceone/identity/service/workspace_group_service.py
+++ b/src/spaceone/identity/service/workspace_group_service.py
@@ -760,6 +760,9 @@ class WorkspaceGroupService(BaseService):
         return len(user_rb_ids)
 
     def _update_workspace_user_count(self, workspace_id: str, domain_id: str) -> None:
+        if not workspace_id and not domain_id:
+            return
+
         workspace_vo = self.workspace_mgr.get_workspace(workspace_id, domain_id)
 
         if workspace_vo and workspace_vo.workspace_id != "*":

--- a/src/spaceone/identity/service/workspace_group_service.py
+++ b/src/spaceone/identity/service/workspace_group_service.py
@@ -517,8 +517,10 @@ class WorkspaceGroupService(BaseService):
             workspace_id=workspace_group_workspace_ids,
             domain_id=domain_id,
         )
+
         for rb_vo in rb_vos:
             self.rb_mgr.delete_role_binding_by_vo(rb_vo)
+            self._update_workspace_user_count(rb_vo.workspace_id, rb_vo.domain_id)
 
     def add_users_to_workspace_group(
         self,
@@ -665,6 +667,7 @@ class WorkspaceGroupService(BaseService):
         if rb_vos.count() > 0:
             for rb_vo in rb_vos:
                 self.rb_mgr.delete_role_binding_by_vo(rb_vo)
+                self._update_workspace_user_count(rb_vo.workspace_id, rb_vo.domain_id)
 
         updated_users = [user for user in old_users if user["user_id"] not in user_ids]
 
@@ -743,3 +746,26 @@ class WorkspaceGroupService(BaseService):
 
         for role_binding_vo in role_binding_vos:
             role_binding_vo.update({"role_id": role_id, "role_type": role_type})
+
+    def _get_workspace_user_count(self, workspace_id: str, domain_id: str) -> int:
+        user_rb_ids = self.rb_mgr.stat_role_bindings(
+            query={
+                "distinct": "user_id",
+                "filter": [
+                    {"k": "workspace_id", "v": workspace_id, "o": "eq"},
+                    {"k": "domain_id", "v": domain_id, "o": "eq"},
+                ],
+            }
+        ).get("results", [])
+        return len(user_rb_ids)
+
+    def _update_workspace_user_count(self, workspace_id: str, domain_id: str) -> None:
+        workspace_vo = self.workspace_mgr.get_workspace(workspace_id, domain_id)
+
+        if workspace_vo and workspace_vo.workspace_id != "*":
+            user_rb_total_count = self._get_workspace_user_count(
+                workspace_id, domain_id
+            )
+            self.workspace_mgr.update_workspace_by_vo(
+                {"user_count": user_rb_total_count}, workspace_vo
+            )

--- a/src/spaceone/identity/service/workspace_service.py
+++ b/src/spaceone/identity/service/workspace_service.py
@@ -2,7 +2,6 @@ import logging
 from datetime import datetime
 from typing import Dict, List, Union
 
-from spaceone.core import cache
 from spaceone.core.service import *
 from spaceone.core.service.utils import *
 from spaceone.identity.error.error_workspace import *
@@ -203,7 +202,7 @@ class WorkspaceService(BaseService):
             for rb_vo in rb_vos:
                 self.rb_mgr.delete_role_binding_by_vo(rb_vo)
 
-        self.workspace_mgr.delete_workspace_by_vo(workspace_vo) 
+        self.workspace_mgr.delete_workspace_by_vo(workspace_vo)
 
     @transaction(permission="identity:Workspace.write", role_types=["DOMAIN_ADMIN"])
     @convert_model
@@ -631,6 +630,7 @@ class WorkspaceService(BaseService):
         )
         for rb_vo in rb_vos:
             self.rb_mgr.delete_role_binding_by_vo(rb_vo)
+            self._update_workspace_user_count(rb_vo.workspace_id, rb_vo.domain_id)
 
     @staticmethod
     def _create_role_bindings(
@@ -650,4 +650,27 @@ class WorkspaceService(BaseService):
                     "workspace_group_id": workspace_group_id,
                     "workspace_id": workspace_id,
                 }
+            )
+
+    def _get_workspace_user_count(self, workspace_id: str, domain_id: str) -> int:
+        user_rb_ids = self.rb_mgr.stat_role_bindings(
+            query={
+                "distinct": "user_id",
+                "filter": [
+                    {"k": "workspace_id", "v": workspace_id, "o": "eq"},
+                    {"k": "domain_id", "v": domain_id, "o": "eq"},
+                ],
+            }
+        ).get("results", [])
+        return len(user_rb_ids)
+
+    def _update_workspace_user_count(self, workspace_id: str, domain_id: str) -> None:
+        workspace_vo = self.workspace_mgr.get_workspace(workspace_id, domain_id)
+
+        if workspace_vo and workspace_vo.workspace_id != "*":
+            user_rb_total_count = self._get_workspace_user_count(
+                workspace_id, domain_id
+            )
+            self.workspace_mgr.update_workspace_by_vo(
+                {"user_count": user_rb_total_count}, workspace_vo
             )

--- a/src/spaceone/identity/service/workspace_service.py
+++ b/src/spaceone/identity/service/workspace_service.py
@@ -665,6 +665,9 @@ class WorkspaceService(BaseService):
         return len(user_rb_ids)
 
     def _update_workspace_user_count(self, workspace_id: str, domain_id: str) -> None:
+        if not workspace_id and not domain_id:
+            return
+
         workspace_vo = self.workspace_mgr.get_workspace(workspace_id, domain_id)
 
         if workspace_vo and workspace_vo.workspace_id != "*":


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
- Remove the rule that a workspace must always have one owner
- Check if the role exists when disabling a role

### Known issue
